### PR TITLE
Capitalise first character in directive  name

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -6,6 +6,7 @@ var path = require('path');
 var _ = require('lodash');
 var mkdirp = require('mkdirp');
 var util = require('util');
+var capitalizeFirstChar = require('capitalize-first-char');
 
 //init CLI options
 program
@@ -34,7 +35,8 @@ mkdirp.sync(folderName)
 
 //template data
 var tmplData = {
-  componentName: componentName
+  componentName: componentName,
+  capitalizeFirstChar: capitalizeFirstChar
 }
 
 //bootstrap file

--- a/bin/templates/default.tmpl
+++ b/bin/templates/default.tmpl
@@ -2,7 +2,7 @@ import angular from 'angular';
 
 var <%= componentName %> = angular.module('<%= componentName %>', []);
 
-<%= componentName %>.directive('gu<%= componentName %>', function <%= componentName %>Directive(){
+<%= componentName %>.directive('gu<%= capitalizeFirstChar(componentName) %>', function <%= componentName %>Directive(){
   return {
 
   };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   "license": "ISC",
   "dependencies": {
     "angular": "^1.3.14",
-    "jspm": "^0.14.0"
+    "capitalize-first-char": "^1.0.0",
+    "install": "^0.1.8",
+    "jspm": "^0.14.0",
+    "npm": "^2.7.1"
   },
   "devDependencies": {
     "babel": "^4.7.8",


### PR DESCRIPTION
Previously `gen -n modal` would name the directive `gumodal` instead of `guModal`.
