### PR TITLE
Bump node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "^3.5.0",
     "mkdirp": "^0.5.0",
     "mversion": "^1.10.0",
-    "node-sass": "^3.0.0-pre",
+    "node-sass": "^3.0.0",
     "normalize.css": "^3.0.2",
     "q": "^1.2.0",
     "wr": "^1.3.1"


### PR DESCRIPTION
`node-sass` have deleted the 3.0.0-pre tag I think. This should get the latest beta / release on install.
