### PR TITLE
Add a start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "watch-sass": "wr ./bin/build-sass-cli ./sass/**/*.scss",
     "postinstall": "jspm install -y && npm run build-sass",
     "watch": "http-server & npm run watch-sass",
-    "build": "npm run build-sass"
+    "build": "npm run build-sass",
+    "start": "http-server"
   },
   "bin": {
     "gen": "bin/index"
@@ -33,7 +34,7 @@
     "lodash": "^3.5.0",
     "mkdirp": "^0.5.0",
     "mversion": "^1.10.0",
-    "node-sass": "^3.0.0",
+    "node-sass": "3.0.0-beta.5",
     "normalize.css": "^3.0.2",
     "q": "^1.2.0",
     "wr": "^1.3.1"


### PR DESCRIPTION
Tiny change to allow deploy on heroku.

Just an experiment to address #31 
Heroku has hooks so that every time you create a PR it deploys your app to a new container, however I'm not an Admin in GH so I can't set up the hook.

The app is running on `https://tools-components.herokuapp.com/`
